### PR TITLE
Add content for Literate Programming lightning talk

### DIFF
--- a/Literate Programming/README.md
+++ b/Literate Programming/README.md
@@ -1,0 +1,16 @@
+# Lightning talk: Literate programming with codedown
+
+Codedown is a little utility to extract code blocks from Markdown files.
+It can be used to help check the correctness of code in articles and
+slideshows, or even to allow Markdown to be the distribution format
+for a project's source code.
+
+In this talk, we look at literate programming's roots, how Haskell
+provides built-in support for it, and how codedown enables literate
+programming in any language.
+
+* Slides from this talk:
+  https://earldouglas.com/presentations/codedown/slides.html
+* Source code for the codedown project:
+  https://github.com/earldouglas/codedown
+


### PR DESCRIPTION
Includes abstract and links to slides and source code.

Should we make a subdirectory for lightning talks?  Or should we prefix directory names with `Lightning talk: <talk name>`?
