### PR TITLE
Add links to Keith Pinson's LambdaConf 2016 slides

### DIFF
--- a/Who Let Algebra Get Funky with My Data Types/README.md
+++ b/Who Let Algebra Get Funky with My Data Types/README.md
@@ -1,0 +1,9 @@
+# Who Let Algebra Get Funky with My Data Types?
+
+The slides are available from the Slide.js-based site
+[Slid.es](http://slides.com/kazark/algebra-funky-types-short). A longer version
+of the slides that was presented as an AfterDark session at CodeMash 2016 is
+available [here](http://slides.com/kazark/algebra-funky-types). You can contact
+the speaker on Twitter @keithtpinson.
+
+

--- a/Your Esoteric Benefactor The Simple Richness of Lambda Calculus/README.md
+++ b/Your Esoteric Benefactor The Simple Richness of Lambda Calculus/README.md
@@ -1,0 +1,5 @@
+# Your Esoteric Benefactor: The Simple Richness of Lambda Calculus
+
+The slides are available from the Slide.js-based site
+[Slid.es](http://slides.com/kazark/lambda-esoteric-benefactor). You can contact
+the speaker on Twitter @keithtpinson.


### PR DESCRIPTION
Add links to Keith Pinson's LambdaConf 2016 slides. There are no other materials to include.

Thanks everyone for a fantastic conference.
